### PR TITLE
Possible Error  in Calculate_STDandMean calculation

### DIFF
--- a/histoCAT/Neighborhood_New/Calculate_STDandMean.m
+++ b/histoCAT/Neighborhood_New/Calculate_STDandMean.m
@@ -33,8 +33,8 @@ for i=1:size(combos_all,1)
     eachCount = sum(eachLogic,2);
     atLeastX = eachCount > patch_det;
     
-    [Ncount,~] = histc(row_cluster_matrix, Get_unique_rows(atLeastX)); % this will give the number of occurences of each unique element  
-    Ncount_zero = [Ncount;zeros(size(Neighbor_Matrix,1)-size(Intersect_combos_all,1),1)];
+    %[Ncount,~] = histc(row_cluster_matrix, Get_unique_rows(atLeastX)); % this will give the number of occurences of each unique element  
+    Ncount_zero = [eachCount(atLeastX);zeros(size(Neighbor_Matrix,1)-size(Intersect_combos_all,1),1)];
     % Save in matrix
     combos_all_histcount(i,3) = mean(Ncount_zero);
 end


### PR DESCRIPTION
In line 36 the histc function doesn't give the number of  occurences for each unique element. Histc measures the number of rows that are included in the bins specified from Get_unique_rows variable. In that way we do not get the number of discrete occurences that are affiliated with the specific rows, but the number of rows that are included in the bin.