### PR TITLE
Fix bugs in data transformation and “special	cluster” matching

### DIFF
--- a/histoCAT/Loading_New/DataProcessing/Process_SingleCell_Tiff_Mask.m
+++ b/histoCAT/Loading_New/DataProcessing/Process_SingleCell_Tiff_Mask.m
@@ -95,7 +95,7 @@ for k=1:size(masks,2)
             if strcmp(transform_option_string,'Do not transform data')==1
                Current_singlecellinfo_nospatial = mean_tab;
             elseif strcmp(transform_option_string,'arcsinh')==1
-               Current_singlecellinfo_nospatial = asinh(mean_tab ./ arcsinh_cofactor{1});
+               Current_singlecellinfo_nospatial = asinh(mean_tab ./ str2num(arcsinh_cofactor{1}));
             elseif strcmp(transform_option_string,'log')==1
                Current_singlecellinfo_nospatial = log(mean_tab);
             end

--- a/histoCAT/Neighborhood_New/Heatmap_individual_images.m
+++ b/histoCAT/Neighborhood_New/Heatmap_individual_images.m
@@ -116,7 +116,7 @@ else
     
     % Search for special cases
     Special_clusters = [];
-    Special_clusters = find(~cellfun(@isempty,regexp(Unique_all_string_names,Special_clusters_name,'match')));
+    Special_clusters = find(~cellfun(@isempty,regexp(Unique_all_string_names,strcat('_',Special_clusters_name,'$|^',Special_clusters_name,'_'),'match')));
     Special_cluster= Matrix_Delta(:,Special_clusters);
     
     % Show heatmap


### PR DESCRIPTION
Hi, 

I am using HistoCAT to treatwith IMC figures these days, this is really a good tool to explore the multiplex tissue images.

Recently, I found the expression value in exported csv files seems very small when arcsinh transformation is used,  I checked the Process_SingleCell_Tiff_Mask.m, and realise that the cofactor it is really using is the ASCII code of the character I typed.   For example, when cofactor is '5', 53 is used as the cofactor. So I made a small modification, using str2num to change the character to number.(please refer to fig1)

The second small modification is related to the "Special cluster" selection. I noticed that when cluster7 is selected cluster 17,27 will also be showed in the clustergram(fig2), so I try to write a  more precise regular expression to avoid this.

![fig1](https://user-images.githubusercontent.com/42300318/92275124-18f6ad00-ef21-11ea-9340-2774597f1885.png)
![fig2](https://user-images.githubusercontent.com/42300318/92275127-1bf19d80-ef21-11ea-821c-3e456335e997.jpg)

Best wishes!
Xinlei Chen